### PR TITLE
Use the explicit app-level configuration:

### DIFF
--- a/lib/Dancer2/Plugin/ProgressStatus.pm
+++ b/lib/Dancer2/Plugin/ProgressStatus.pm
@@ -97,7 +97,7 @@ use Dancer2::Core::Response;
 sub _progress_status_file {
     my ( $dsl, $name ) = @_;
 
-    my $dir = $dsl->config->{'plugins'}->{ProgressStatus}->{dir}
+    my $dir = $dsl->app->config->{'plugins'}{ProgressStatus}{dir}
                 or croak 'No ProgressStatus plugin settings in config';
     if ( !-d $dir ) {
         File::Path::make_path($dir) or die "Cannot create path $dir";


### PR DESCRIPTION
In D2P2 (new Dancer2 plugin system), the `config` method retrieves
the configuration of the specific plugin. Using `$app->config`,
we'll be able to retain the app configuration explicitly.
